### PR TITLE
Generate static binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ provider_version="0.3"
 provider_file_name="$(provider_name)_v$(provider_version)"
 
 build:
-	go build -o $(provider_file_name)
+	CGO_ENABLED=0 go build -o $(provider_file_name) -tags netgo -a -v
 
 format:
 	go fmt


### PR DESCRIPTION
Changed build command to generate a static binary. On Linux, linked library paths may differ between distributions, for example, dynamic binaries built on Alpine will not work on Debian (and vice-versa).